### PR TITLE
initial host→client remote control

### DIFF
--- a/dots/dots.css
+++ b/dots/dots.css
@@ -6,5 +6,5 @@ html, body {
   padding: 0;
 }
 canvas {
-  display: block;
+  /* display: block; */
 }

--- a/dots/dots.js
+++ b/dots/dots.js
@@ -2,6 +2,7 @@
 /*
  * @name EMDR
  * @description Eye Movement Desensitization and Reprocessing
+ * @author Forrest Oliphant, Alex Danilowicz
  */
 
 const ballSize = 50;
@@ -9,7 +10,7 @@ const ballSize = 50;
 let x, y, width, height;
 let button, slider;
 let speed = 1;
-let playing = true;
+let playing = false;
 let playTime = 0;
 
 let leftSound = false;
@@ -20,15 +21,29 @@ let rightSound = false;
 */
 
 function togglePlay() {
-  playing = !playing;
   playTime = millis();
-  // Toggle button label
-  button.html(playing ? "Pause" : "Play");
   // Reset position
   x = width / 2;
   // Reset sounds
   leftSound = false;
   rightSound = false;
+}
+
+function dotsPlay (newSpeed) {
+  playing = true;
+  if (newSpeed != null) {
+    speed = newSpeed;
+  }
+  togglePlay();
+}
+
+function dotsPause () {
+  playing = false;
+  togglePlay();
+}
+
+function dotsSpeed (newSpeed) {
+  speed = newSpeed;
 }
 
 /* 
@@ -42,32 +57,32 @@ function preload() {
 
 // Responsiveness: fits canvas to window
 function windowResized() {
-  width = windowWidth - 1;
-  height = windowHeight - 51;
+  width = windowWidth;
+  height = windowHeight - 175;
+  y = height / 2;
   resizeCanvas(width, height);
 }
 
 function setup() {
   windowResized();
   createCanvas(width, height);
-  slider = createSlider(0, 5, speed, 0.1);
-  button = createButton('Pause');
-  button.mousePressed(togglePlay);
-  x = ballSize;
-  y = height / 2;
+  x = width / 2;
 }
 
 // Runs once per frame of animation
 function draw() {
   background(220);
 
+  if (!playing) {
+    x = width / 2;
+  }
+
   // Draw a circle
   stroke(50);
   fill(200);
-  ellipse(x, y, ballSize, ballSize);
+  ellipse(x, y, ballSize);
 
   if (playing) {
-    speed = slider.value();
     const timeElapsed = millis() - playTime;
     const wave = sin(timeElapsed / 1000 * speed);
     // Boop left

--- a/dots/emdr-p2p.js
+++ b/dots/emdr-p2p.js
@@ -1,0 +1,92 @@
+const peer = new Peer();
+let clients = [];
+
+peer.on("connection", function(conn) {
+  clients.push(conn);
+  conn.on("data", function(data) {
+    console.log(data);
+    document.getElementById("peer").textContent = JSON.stringify(data);
+  });
+});
+
+function initHost() {
+  peer.on("open", function(id) {
+    const clientUrl = location.href.split("#")[0] + "#" + id;
+    document.getElementById("url").textContent = clientUrl;
+  });
+
+  document.getElementById("host").style.display = "block";
+  document.getElementById("play").addEventListener("click", function() {
+    clients.forEach(function(client) {
+      client.send({
+        type: "play",
+        payload: { speed: document.getElementById("speed").value }
+      });
+    });
+  });
+  document.getElementById("pause").addEventListener("click", function() {
+    clients.forEach(function(client) {
+      client.send({ type: "pause" });
+    });
+  });
+  document.getElementById("speed").addEventListener("input", function(event) {
+    clients.forEach(function(client) {
+      client.send({ type: "speed", payload: event.target.value });
+    });
+  });
+}
+
+function initClient(hostId) {
+  const conn = peer.connect(hostId);
+  // on open will be launch when you successfully connect to PeerServer
+  conn.on("open", function() {
+    // Sending hello to host
+    conn.send({
+      type: "hello",
+      payload: { client: peer.id, host: hostId, connection: conn.id }
+    });
+  });
+  conn.on("data", function(data) {
+    console.log(data);
+    switch (data.type) {
+      case "play": {
+        dotsPlay(data.payload.speed);
+        conn.send({
+          type: "ack",
+          payload: data
+        });
+        break;
+      }
+      case "pause": {
+        dotsPause();
+        conn.send({
+          type: "ack",
+          payload: data
+        });
+        break;
+      }
+      case "speed": {
+        dotsSpeed(data.payload);
+        conn.send({
+          type: "ack",
+          payload: data
+        });
+        break;
+      }
+      default: {
+        conn.send({
+          type: "error",
+          payload: "unknown type " + data.type
+        });
+      }
+    }
+  });
+}
+
+// On startup, decide if host or client, depending on url hash
+if (location.hash === "#host") {
+  initHost();
+} else if (location.hash.length > 7) {
+  const hostId = location.hash.split("#")[1];
+  initClient(hostId);
+}

--- a/dots/index.html
+++ b/dots/index.html
@@ -1,17 +1,30 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <!-- Library code -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.sound.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="dots.css">
+    <script src="https://unpkg.com/peerjs@1.0.0/dist/peerjs.min.js"></script>
+    <link rel="stylesheet" type="text/css" href="dots.css" />
     <meta charset="utf-8" />
   </head>
   <body>
+    <div id="host" style="display: none;">
+      <h1>Host</h1>
+      <pre id="url">Connecting...</pre>
+      <button id="play">Play</button>
+      <button id="pause">Pause</button>
+      <input id="speed" type="range" min="0" max="10" value="2" />
+      <pre id="peer"></pre>
+    </div>
+    <!-- <form>
+      <textarea id="incoming"></textarea>
+      <button type="submit">submit</button>
+    </form> -->
+
+    <!-- App code -->
     <script src="dots.js"></script>
-    
-    <h1>TEST CONTENT</h1>
-    
-    
+    <script src="emdr-p2p.js"></script>
   </body>
 </html>


### PR DESCRIPTION
This is a rough proof of concept, and should be tested lots and polished before using for real.

How to test:
1. Merge this pull request
2. Go to `/dots/#host` in one browser
3. Wait for url to show with session id, like `/dots/#gf4h4m7im5r00000`
4. Open that in another browser
5. See `"type":"hello"` message on host instance, now you should be able to control client from host

Things to test and/or fix:

- [ ] Client needs to tap / click before sounds will play
- [ ] Client volume control
- [ ] WAV not working in Safari?
- [ ] UI on host to see that client is still connected
- [ ] Test various network conditions
- [ ] Test mobile browsers
- [ ] Firefox

etc 🐲 